### PR TITLE
Add interactive BOM link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ There are interfaces for GY-291 (ADXL345 accelerometer) and GY-271 (HMC5883L mag
 
 ![BOB2-front](pics/bob-front.png)
 
-An interactive html BOM file with pcb layout and material placement can be
-found [here](bom/ibom.html).
+# Interactive BOM
+
+An interactive html BOM page with pcb layout and material placement can be found [here](https://emtpb.github.io/pmi-hw-bob2/bom/ibom.html).
 
 # Changelog
 


### PR DESCRIPTION
This pull request adds a GitHub Pages link to the interactive bill of materials (BOM) in the README.